### PR TITLE
Configure production API URL for frontend

### DIFF
--- a/frontend/src/contexts/SocketContext.jsx
+++ b/frontend/src/contexts/SocketContext.jsx
@@ -22,8 +22,14 @@ export const SocketProvider = ({ children }) => {
     
     if (!token) return;
 
-    // Initialize socket connection
-    const newSocket = io(import.meta.env.VITE_API_URL || 'http://localhost:3001', {
+    // Initialize socket connection with environment-aware base URL
+    const isLocalHost = typeof window !== 'undefined' && /^(localhost|127\.0\.0\.1)$/i.test(window.location.hostname);
+    const rawBase = isLocalHost
+      ? (import.meta.env.VITE_LOCAL_API_URL || 'http://localhost:3001/api/v1')
+      : (import.meta.env.VITE_PROD_API_URL || import.meta.env.VITE_API_URL || '');
+    const SOCKET_BASE_URL = (rawBase && rawBase.replace(/\/$/, '').replace(/\/api\/v1\/?$/, '')) || 'http://localhost:3001';
+
+    const newSocket = io(SOCKET_BASE_URL, {
       auth: {
         token
       }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,4 +1,13 @@
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001/api/v1';
+// Determine API base URL based on environment and hostname
+// Priority:
+// 1) If running on localhost/127.0.0.1, use VITE_LOCAL_API_URL (fallback to localhost default)
+// 2) Otherwise, use VITE_PROD_API_URL (fallback to VITE_API_URL for backward compatibility)
+const isLocalHost = typeof window !== 'undefined' && /^(localhost|127\.0\.0\.1)$/i.test(window.location.hostname);
+const API_BASE_URL = (
+  isLocalHost
+    ? (import.meta.env.VITE_LOCAL_API_URL || 'http://localhost:3001/api/v1')
+    : (import.meta.env.VITE_PROD_API_URL || import.meta.env.VITE_API_URL)
+);
 
 class ApiService {
   constructor() {


### PR DESCRIPTION
Dynamically select API and Socket.IO base URLs based on environment to prevent `localhost` calls in production.

---
<a href="https://cursor.com/background-agent?bcId=bc-2a70e46d-6b3d-4be4-95d6-fbbfa2c0d43d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2a70e46d-6b3d-4be4-95d6-fbbfa2c0d43d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

